### PR TITLE
social 卡圖只在 CI 產生（修正本機 Cairo 警告噪音）

### DIFF
--- a/src/site_docs/mkdocs.yml
+++ b/src/site_docs/mkdocs.yml
@@ -95,6 +95,9 @@ plugins:
         - zh
         - en
   - social:
+      # 卡圖只在 CI 產生（GitHub Actions 會設 CI=true）；本機 build 跳過，
+      # 避免本機缺 Cairo 時噴大量警告、也讓本機建置更快。
+      enabled: !ENV [CI, false]
       cards_layout_options:
         font_family: Noto Sans TC
         color: "#ffffff"


### PR DESCRIPTION
## 背景

先前標記的兩個「問題」，經查證**正式環境其實都正常**：
- social 卡圖：正式站 `og:image` 為 200、部署 log 0 次 cairo 失敗（ubuntu runner 有 libcairo）
- git-revision 時間順序警告：正式部署 log 0 次

唯一真實（較小）的問題是**本機 build 體驗**：在缺 Cairo 的環境（多為 mac）跑 `mkdocs build`／`serve` 會噴 ~200 個 cairosvg 警告，對日後志工很不友善。

## 修正

`mkdocs.yml` 的 social 外掛改用 Material 官方建議：
```yaml
- social:
    enabled: !ENV [CI, false]
```
- GitHub Actions 會自動設 `CI=true` → **部署與 PR 建置照常產生卡圖**（行為不變）
- 本機無 `CI` → social 跳過 → build 乾淨、更快、不需安裝 Cairo

## 驗證（本機）
- `mkdocs build`（無 CI）：exit 0、**0 cairo 警告**、卡圖跳過、license 圖正常、0 斷連結
- `CI=true mkdocs build`：cairo 警告重新出現 → 證明 CI 模式下卡圖仍會產生
- 本 PR 的建置檢查（CI=true）即會實際產生卡圖，綠燈代表正式路徑不受影響

## 未改動
- git-revision 的本機警告（不影響正式站）：`enable_git_follow: false` 會犧牲「檔案改名後仍保留原始建立日期」的準確性，為了一個本機 cosmetic 警告不值得，故保留現狀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)