### PR TITLE
feat(mails): 續約提醒名單工具 + 年度排程提醒 (#23)

### DIFF
--- a/.github/workflows/renew-reminder.yml
+++ b/.github/workflows/renew-reminder.yml
@@ -1,0 +1,64 @@
+name: Renew reminder
+
+# 讓「年度續約提醒」不會被忘記（issue #23）：
+# 每年 COSCUP 前自動開一張提醒 issue，附上寄送 renew 信的操作清單。
+# 只開 issue、不寄信也不碰申請者資料，因此不需要任何密鑰。
+on:
+  schedule:
+    # 每年 6/1 00:00 UTC（＝台灣 08:00），約在 COSCUP（通常 8 月）前兩個月
+    - cron: "0 0 1 6 *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+concurrency:
+  group: renew-reminder
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open renew reminder issue (skip if it already exists)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const year = new Date().getUTCFullYear();
+            const title = `[OSCVPass] ${year} 年度續約提醒信寄送（COSCUP 前）`;
+
+            // 用既有 issue 標題去重，避免重複建立
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            if (existing.some((i) => !i.pull_request && i.title === title)) {
+              core.info(`提醒 issue 已存在，略過：${title}`);
+              return;
+            }
+
+            const body = [
+              '自動提醒：COSCUP 將至，請寄送今年度的續約（Renew）提醒信，',
+              '通知即將／已到期的貢獻者回來更新資格。',
+              '',
+              '操作步驟（詳見 `mails/README.md` 的「年度續約提醒」）：',
+              '',
+              '- [ ] 從核准名單匯出最新 CSV（含 `start_date` / `nickname` / `mail`）',
+              '- [ ] `uv run python send_renew.py --source approved.csv --out renew.csv` 並檢查名單',
+              '- [ ] `--send`（dry-run）寄一封測試信確認版面',
+              '- [ ] `--send --no-dry-run` 正式寄出',
+              '- [ ] 完成後關閉本 issue',
+              '',
+              '> 本 issue 由 `.github/workflows/renew-reminder.yml` 自動建立。',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['mails'],
+              body,
+            });
+            core.info(`已建立提醒 issue：${title}`);

--- a/mails/README.md
+++ b/mails/README.md
@@ -1,3 +1,76 @@
 # mails
 
-This folder project for sending mail scripts by using AWS SES.
+OSCVPass 透過 **AWS SES** 寄送樣板信件的工具與操作說明。
+信件樣板放在 `tpl/`，寄送邏輯在 `awssestools.py`，續約提醒名單工具在 `send_renew.py`。
+
+> 寄件者為已在 SES 驗證的 `oscvpass@ocf.tw`（見 `awssestools.py` 的 `MAIL_SOURCE`）。
+
+## 環境設定
+
+```bash
+cd mails
+cp setting.py.sample setting.py   # 填入 AWS 憑證、測試信箱、封鎖名單
+uv sync                            # 安裝相依套件（arrow / boto3 / jinja2）
+```
+
+`setting.py` 已被 `.gitignore` 忽略，**請勿提交**。欄位說明見 `setting.py.sample`。
+
+## 安全須知
+
+- 幾乎所有寄送函式都支援 **`dry_run`**，預設只寄一封測試信到 `setting.TESTMAIL`。
+- 確認名單與信件內容無誤後，再改為正式寄送（`dry_run=False` 或 `--no-dry-run`）。
+- `setting.BLOCK` 內的信箱永遠不會收到信。
+
+## 年度續約提醒（issue #23）
+
+提醒「即將／已到期」的貢獻者回來更新資格，建議在 **COSCUP 前一兩個月**執行。
+
+1. 從核准名單（Google Forms／試算表）匯出 CSV，至少包含：起始日
+   （`start_date`）、暱稱（`nickname`，可退回 `name`）、email（`mail`，可退回
+   `mail2`）；若有 `status` 欄則只會處理「通過」者。
+2. 篩出名單並肉眼檢查（**不寄信**）：
+
+   ```bash
+   uv run python send_renew.py --source approved.csv --out renew.csv
+   # 預設納入「未來 60 天內到期」者；要一併提醒剛過期者：
+   uv run python send_renew.py --source approved.csv --out renew.csv --expired-within-days 60
+   ```
+
+   會印出每位的到期日與「即將／已」到期標記，並輸出 `renew.csv`
+   （欄位 `date,nickname,mail`，對應 `tpl/expired.html`）。
+3. 先寄一封測試信給自己（`setting.TESTMAIL`）：
+
+   ```bash
+   uv run python send_renew.py --source approved.csv --send
+   ```
+
+4. 確認無誤後正式寄給所有人：
+
+   ```bash
+   uv run python send_renew.py --source approved.csv --send --no-dry-run
+   ```
+
+常用參數：`--within-days N`（未來幾天內到期，預設 60）、`--expired-within-days N`
+（也納入過去幾天內過期者，預設 0）、`--years N`（資格效期，預設 1）、`--today
+YYYY-MM-DD`（覆寫基準日，方便測試）。完整參數見 `send_renew.py --help`。
+
+> `.github/workflows/renew-reminder.yml` 會在每年 COSCUP 前自動開一張提醒
+> issue，避免忘記執行上述流程。
+
+## 審核結果通知（pass / 補件 / 拒絕）
+
+`awssestools.py` 的 `process_csv()` 會依匯出名單的 `status` 欄分流到
+`pass` / `insufficient_for` / `deny` 三類，再由 `send()` 套用對應樣板寄出。
+範例已寫在 `awssestools.py` 的 `__main__` 區塊（預設註解、`dry_run=True`）：
+
+```python
+data = process_csv('./oscvpass_xxxxxx.csv', _all=False)  # 只寄尚未寄過（send 欄為空）者
+send(data=data, case=('deny', 'insufficient_for', 'pass'), dry_run=True)
+```
+
+確認後將 `dry_run` 改為 `False` 正式寄送。
+
+## 其他樣板
+
+`tpl/` 內另有各研討會的優惠票券、年度總結、workshop 等一次性信件樣板，
+對應 `awssestools.py` 內的 `send_*` 系列函式，依當年度需求取用。

--- a/mails/send_renew.py
+++ b/mails/send_renew.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""產生「即將／已到期」的續約提醒名單，並（選擇性）透過 AWS SES 寄送。
+
+對應 issue #23：過往貢獻者反映沒有收到續約（Renew）通知，希望在 COSCUP 前
+一兩個月主動提醒回來更新資格。
+
+資料流：
+
+    核准名單 CSV（含 start_date / mail / nickname）
+      │  計算到期日（start_date ＋ N 年，預設 1 年）
+      ▼
+    篩出在 [now − expired_within, now ＋ within] 區間到期者
+      │
+      ▼
+    輸出 renew CSV（欄位：date,nickname,mail）── 給 tpl/expired.html 使用
+      │  （加上 --send）
+      ▼
+    awssestools.send_expired() 透過 AWS SES 寄出
+
+設計原則：
+
+  * 預設「只篩名單、不寄信」，讓你先肉眼檢查名單再決定寄送。
+  * 篩選流程不需要 setting.py 或 AWS 憑證即可在本機執行與測試。
+  * 真正寄送沿用既有、已驗證的 ``awssestools.send_expired``，避免重造輪子。
+
+用法見 README.md 的「年度續約提醒」一節。
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import arrow
+
+
+def _pick(row: dict[str, str], primary: str, fallback: str | None = None) -> str:
+    """取 ``primary`` 欄位，空白時退回 ``fallback``，並去除前後空白。"""
+    value = (row.get(primary) or '').strip()
+    if not value and fallback:
+        value = (row.get(fallback) or '').strip()
+    return value
+
+
+def _expiration(row: dict[str, str], *, date_col: str, start_col: str,
+                years: int) -> arrow.Arrow | None:
+    """算出該筆的到期日。
+
+    優先使用既有的到期日欄位（``date_col``）；沒有時改用起始日
+    （``start_col``）往後加 ``years`` 年。兩者皆無或無法解析則回傳 None。
+    """
+    raw_date = _pick(row, date_col)
+    if raw_date:
+        try:
+            return arrow.get(raw_date)
+        except (ValueError, arrow.parser.ParserError):
+            return None
+
+    raw_start = _pick(row, start_col)
+    if not raw_start:
+        return None
+    try:
+        return arrow.get(raw_start).shift(years=years)
+    except (ValueError, arrow.parser.ParserError):
+        return None
+
+
+def collect(path: Path, *, now: arrow.Arrow, within: int, expired_within: int,
+            years: int, status_col: str, status_value: str,
+            date_col: str, start_col: str,
+            nickname_col: str, name_col: str,
+            mail_col: str, mail2_col: str) -> list[dict[str, str]]:
+    # pylint: disable=too-many-arguments,too-many-locals
+    """讀核准名單 CSV，回傳落在續約提醒區間內的名單。
+
+    區間為 ``[now − expired_within 天, now ＋ within 天]``，涵蓋「即將到期」
+    與「剛過期」兩種需要提醒的對象。回傳欄位為 ``date / nickname / mail``，
+    正是 ``tpl/expired.html`` 與 ``awssestools.send_expired`` 所需。
+    """
+    lower = now.shift(days=-expired_within)
+    upper = now.shift(days=+within)
+
+    picked: list[dict[str, str]] = []
+    with path.open(encoding='UTF8') as files:
+        for row in csv.DictReader(files):
+            # 有 status 欄時，只處理「通過」者；沒有則不過濾。
+            if status_col in row and status_value:
+                if (row.get(status_col) or '').strip() != status_value:
+                    continue
+
+            exp = _expiration(row, date_col=date_col, start_col=start_col,
+                              years=years)
+            if exp is None:
+                continue
+            if not lower <= exp <= upper:
+                continue
+
+            mail = _pick(row, mail_col, mail2_col).lower()
+            if '@' not in mail:
+                continue
+
+            nickname = _pick(row, nickname_col, name_col)
+            picked.append({
+                'date': exp.format('YYYY-MM-DD'),
+                'nickname': nickname or mail,
+                'mail': mail,
+            })
+
+    picked.sort(key=lambda r: r['date'])
+    return picked
+
+
+def write_csv(rows: list[dict[str, str]], path: Path) -> None:
+    """輸出 renew 名單為 ``date,nickname,mail`` 三欄 CSV。"""
+    with path.open('w+', encoding='UTF8') as files:
+        writer = csv.DictWriter(files, fieldnames=('date', 'nickname', 'mail'))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI 進入點：解析參數、篩名單、輸出 CSV，並可選擇寄送。"""
+    parser = argparse.ArgumentParser(
+        description='產生續約提醒名單，並可選擇透過 AWS SES 寄送（issue #23）。')
+    parser.add_argument('--source', required=True, type=Path,
+                        help='核准名單 CSV（需含起始日與 email 欄位）')
+    parser.add_argument('--out', type=Path, default=Path('./renew.csv'),
+                        help='輸出的續約名單 CSV 路徑（預設 ./renew.csv）')
+    parser.add_argument('--within-days', type=int, default=60,
+                        help='納入「未來 N 天內到期」者（預設 60）')
+    parser.add_argument('--expired-within-days', type=int, default=0,
+                        help='也納入「過去 N 天內已過期」者（預設 0＝不納入）')
+    parser.add_argument('--years', type=int, default=1,
+                        help='資格效期年數，用於由起始日推算到期日（預設 1）')
+    parser.add_argument('--today',
+                        help='覆寫「今天」（YYYY-MM-DD），方便測試／回溯')
+
+    # 欄位名稱（預設沿用 awssestools.process_csv 的慣例）
+    parser.add_argument('--status-col', default='status')
+    parser.add_argument('--status-value', default='通過')
+    parser.add_argument('--date-col', default='expiration_date',
+                        help='若來源已有到期日欄位則直接採用')
+    parser.add_argument('--start-col', default='start_date')
+    parser.add_argument('--nickname-col', default='nickname')
+    parser.add_argument('--name-col', default='name')
+    parser.add_argument('--mail-col', default='mail')
+    parser.add_argument('--mail2-col', default='mail2')
+
+    parser.add_argument('--send', action='store_true',
+                        help='篩完後實際呼叫 AWS SES 寄送（需要 mails/setting.py）')
+    parser.add_argument('--no-dry-run', action='store_true',
+                        help='搭配 --send：真的寄給所有人（否則只寄一封測試信）')
+    args = parser.parse_args(argv)
+
+    if not args.source.exists():
+        parser.error(f'找不到來源檔案：{args.source}')
+
+    now = arrow.get(args.today) if args.today else arrow.now()
+
+    rows = collect(
+        args.source, now=now,
+        within=args.within_days, expired_within=args.expired_within_days,
+        years=args.years,
+        status_col=args.status_col, status_value=args.status_value,
+        date_col=args.date_col, start_col=args.start_col,
+        nickname_col=args.nickname_col, name_col=args.name_col,
+        mail_col=args.mail_col, mail2_col=args.mail2_col,
+    )
+
+    write_csv(rows, args.out)
+
+    print(f'基準日：{now.format("YYYY-MM-DD")}　'
+          f'區間：[−{args.expired_within_days}d, +{args.within_days}d]')
+    print(f'符合續約提醒者：{len(rows)} 位　→　已寫入 {args.out}')
+    for row in rows:
+        flag = '即將' if arrow.get(row['date']) >= now else '已'
+        print(f"  {row['date']}  {flag}到期  {row['nickname']}  <{row['mail']}>")
+
+    if not rows:
+        return 0
+
+    if not args.send:
+        print('\n（僅產生名單，未寄信。確認名單後可加 --send 寄出。）')
+        return 0
+
+    # 寄送路徑才需要 setting.py / AWS 憑證，故延後 import。
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import awssestools  # noqa: E402  pylint: disable=import-outside-toplevel
+
+    dry_run = not args.no_dry_run
+    if dry_run:
+        print('\n[dry-run] 僅寄一封測試信到 setting.TESTMAIL；確認無誤後加 --no-dry-run。')
+    else:
+        print(f'\n[正式寄送] 即將寄給 {len(rows)} 位收件者……')
+    awssestools.send_expired(str(args.out), dry_run=dry_run)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/mails/setting.py.sample
+++ b/mails/setting.py.sample
@@ -1,0 +1,13 @@
+''' Setting
+
+複製此檔為 mails/setting.py 後填入實際值（setting.py 已被 .gitignore 忽略，請勿提交）。
+'''
+# AWS SES 憑證（region 固定為 us-east-1，見 awssestools.py）
+AWSID = ''
+AWSKEY = ''
+
+# dry-run 時所有測試信會改寄到這個信箱
+TESTMAIL = ''
+
+# 永遠不寄送的封鎖名單（小寫 email）
+BLOCK = ('', '')


### PR DESCRIPTION
## 解決什麼

issue #23：貢獻者反映沒收到續約（Renew）通知，且團隊容易忘記在 COSCUP 前寄信。

> 背景：`awssestools.py` 早已有 `send_expired()` 能套 `tpl/expired.html` 寄「即將／已到期」通知，缺的是「**把快到期名單篩出來**」的工具、「**別忘記寄**」的排程，以及操作文件。

## 改了什麼

- **`mails/send_renew.py`**（新增）：讀核准名單 CSV，依起始日推算到期日，篩出指定區間內到期者，輸出 `date,nickname,mail` 的 renew CSV（正好對應 `expired.html` / `send_expired`）。
  - 預設只篩名單、不寄信；篩選流程**不需 setting.py 或 AWS 憑證**即可本機執行與測試。
  - `--send`（dry-run，只寄一封測試信）→ `--send --no-dry-run`（正式寄全部），寄送沿用既有 `send_expired`。
  - 支援 `--within-days` / `--expired-within-days` / `--years` / `--today`，欄位名稱可覆寫（預設沿用 `process_csv` 慣例：`status`/`start_date`/`nickname`/`name`/`mail`/`mail2`）。
- **`.github/workflows/renew-reminder.yml`**（新增）：每年 6/1（COSCUP 前約兩個月）自動開一張附操作清單的提醒 issue，已存在則略過。只開 issue、**無密鑰、不碰申請者資料**，延續 repo「無人管理運行」的方向。
- **`mails/README.md`**（更新）：補上 AWS SES 環境設定、安全須知、年度續約提醒 runbook、審核結果通知流程 —— 一併補掉 #31 缺的「操作文件」。
- **`mails/setting.py.sample`**（新增）：補 `mails/` 缺少的設定範本（`setting.py` 已 gitignore）。

## 測試

- `send_renew.py` 以樣板資料驗證：status 過濾、`nickname→name` / `mail→mail2` 退回、到期日計算、未來／已過期視窗、無法解析的日期會略過不 crash。
- `pylint send_renew.py` → 10.00/10；`renew-reminder.yml` 通過 YAML 解析。
- 寄送路徑（AWS SES）需實際憑證與名單，未在此 PR 實際寄信。

Closes #23
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)