### PR TITLE
docs: 標註 src/docs 舊 mdBook 為歷史文件（不再維護）

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,0 +1,11 @@
+# OSCVPass 舊版文件（已不再維護）
+
+> ⚠️ 這是 OSCVPass **早期以 [mdBook](https://github.com/rust-lang/mdBook) 撰寫的文件**，
+> 目前**已不再維護**，也未由任何自動化建置或部署，僅保留作為歷史紀錄。
+
+現行的正式文件已改用 mkdocs（原始碼在 [`../site_docs/`](../site_docs/)），請改參考：
+
+- 線上文件：<https://oscvpass.ocf.tw/docs/>
+
+本資料夾內容可能已過時（例如仍描述當年自架 Pretalx 的規劃，該方向後來已停止），
+請勿據此理解目前的計畫流程。


### PR DESCRIPTION
保留 `src/docs`（舊版 mdBook 文件），但新增 `src/docs/README.md` 清楚標註：

- 這是早期以 mdBook 撰寫的文件，**已不再維護**，也未被任何 CI 建置／部署。
- 現行文件改用 mkdocs（`src/site_docs/`），線上版 https://oscvpass.ocf.tw/docs/ 。
- 內容可能過時（例如仍描述已停止的自架 Pretalx 規劃），請勿據此理解目前流程。

瀏覽 `src/docs/` 目錄時 GitHub 會直接渲染此 README；mdBook 的 build src 為
`src/docs/src/`，故此檔不影響（也不會被打包進）原書內容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)